### PR TITLE
Create action.yml

### DIFF
--- a/.github/actions/api-compatibility-check/action.yml
+++ b/.github/actions/api-compatibility-check/action.yml
@@ -60,50 +60,92 @@ runs:
                 ./ current_headers/
         else
           # rsyncが利用できない場合はfindとcpを使用
-          find . -maxdepth 10 \( -name "*.h" -o -name "*.hpp" -o -name "*.hxx" \) \
+          # rsyncが利用できない場合はfindとcpを使用
+          find . \( -name "*.h" -o -name "*.hpp" -o -name "*.hxx" \) \
                  -not -path "./current_headers/*" -not -path "./baseline_headers/*" \
-                 -not -path "./.git/*" | while read file; do
-            target_dir="current_headers/$(dirname "$file")"
-            mkdir -p "$target_dir"
-            cp "$file" "current_headers/$file"
+                 -not -path "./.git/*" -print0 | while IFS= read -r -d $'\0' file; do
+            # Remove leading './' if present
+            cleaned_file=$(echo "$file" | sed 's|^\./||')
+            target_file="current_headers/$cleaned_file"
+            mkdir -p "$(dirname "$target_file")"
+            cp "$file" "$target_file"
           done
         fi
         
     - name: Create descriptors
       shell: bash
       run: |
-        # skip-patternsを配列に変換
-        IFS=',' read -ra SKIP_PATTERNS <<< "${{ inputs.skip-patterns }}"
+        # --- Helper for GCC options ---
+        GCC_OPTIONS_FORMATTED=$(echo "${{ inputs.gcc-options }}" | tr ' ' '\n')
+
+        # --- Prepare baseline.xml ---
+        # Process include-paths for baseline
+        IFS=',' read -ra INCLUDE_PATHS_ARRAY <<< "${{ inputs.include-paths }}"
+        INCLUDE_XML_BASELINE=""
+        for path_item in "${INCLUDE_PATHS_ARRAY[@]}"; do
+          if [ -n "$path_item" ]; then # Ensure path_item is not empty
+            INCLUDE_XML_BASELINE="${INCLUDE_XML_BASELINE}\$(pwd)/baseline_headers/$path_item\n"
+          fi
+        done
+        INCLUDE_XML_BASELINE="${INCLUDE_XML_BASELINE}/usr/include" # Add default /usr/include
+
+        # Process skip-patterns for baseline (same for current)
+        IFS=',' read -ra SKIP_PATTERNS_ARRAY <<< "${{ inputs.skip-patterns }}"
         SKIP_XML=""
-        for pattern in "${SKIP_PATTERNS[@]}"; do
-          SKIP_XML="$SKIP_XML<n>$pattern</n>"
+        for pattern in "${SKIP_PATTERNS_ARRAY[@]}"; do
+          if [ -n "$pattern" ]; then # Ensure pattern is not empty
+            SKIP_XML="${SKIP_XML}$pattern\n"
+          fi
         done
+        # Remove trailing newline from SKIP_XML if it exists, otherwise api-sanity-checker might complain about an empty line
+        SKIP_XML=$(echo -e "$SKIP_XML" | sed '/^$/d')
         
-        # include-pathsを処理
-        IFS=',' read -ra INCLUDE_PATHS <<< "${{ inputs.include-paths }}"
-        INCLUDE_XML=""
-        for path in "${INCLUDE_PATHS[@]}"; do
-          INCLUDE_XML="$INCLUDE_XML<path>\$(pwd)/baseline_headers/$path</path>"
-        done
-        
-        # baseline.xml生成
+        echo "Generating baseline.xml..."
         cat > baseline.xml << EOF
         <?xml version="1.0" encoding="UTF-8"?>
-        <descriptor>
-            <version>baseline</version>
-            <headers>\$(pwd)/baseline_headers/${{ inputs.include-paths }}</headers>
-            <include_paths>
-                $INCLUDE_XML
-                <path>/usr/include</path>
-            </include_paths>
-            <gcc_options>${{ inputs.gcc-options }}</gcc_options>
-            <skip_headers>$SKIP_XML</skip_headers>
-        </descriptor>
+        <version>baseline</version>
+        <headers>\$(pwd)/baseline_headers/${{ inputs.include-paths }}</headers>
+        <include_paths>
+        $(echo -e "$INCLUDE_XML_BASELINE")
+        </include_paths>
+        <gcc_options>
+        $GCC_OPTIONS_FORMATTED
+        </gcc_options>
+        <skip_headers>
+        $(echo -e "$SKIP_XML")
+        </skip_headers>
+        EOF
+
+        # --- Prepare current.xml ---
+        # Process include-paths for current
+        INCLUDE_XML_CURRENT=""
+        for path_item in "${INCLUDE_PATHS_ARRAY[@]}"; do
+          if [ -n "$path_item" ]; then # Ensure path_item is not empty
+            INCLUDE_XML_CURRENT="${INCLUDE_XML_CURRENT}\$(pwd)/current_headers/$path_item\n"
+          fi
+        done
+        INCLUDE_XML_CURRENT="${INCLUDE_XML_CURRENT}/usr/include" # Add default /usr/include
+
+        echo "Generating current.xml..."
+        cat > current.xml << EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <version>current</version>
+        <headers>\$(pwd)/current_headers/${{ inputs.include-paths }}</headers>
+        <include_paths>
+        $(echo -e "$INCLUDE_XML_CURRENT")
+        </include_paths>
+        <gcc_options>
+        $GCC_OPTIONS_FORMATTED
+        </gcc_options>
+        <skip_headers>
+        $(echo -e "$SKIP_XML")
+        </skip_headers>
         EOF
         
-        # current.xml生成  
-        sed 's/baseline_headers/current_headers/g' baseline.xml > current.xml
-        sed -i 's/<version>baseline</<version>current</g' current.xml
+        echo "baseline.xml content:"
+        cat baseline.xml
+        echo "current.xml content:"
+        cat current.xml
         
     - name: Run API compatibility check
       id: check

--- a/.github/workflows/api-compatibility.yaml
+++ b/.github/workflows/api-compatibility.yaml
@@ -44,7 +44,7 @@ jobs:
           exit 1
         elif [ "${{ steps.api_check.outputs.compatible }}" = "error" ]; then
           echo "⚠️ API compatibility check had errors (may be OK for new projects)"
-          exit 0
+          exit 1 # Ensure this is changed
         else
           echo "✅ API compatibility check passed"
           exit 0


### PR DESCRIPTION
This commit resolves several issues in the C++ API compatibility check
GitHub Action and workflow:

1.  **Robust Header Copying:** The fallback mechanism in `action.yml` for
    copying header files (when `rsync` is unavailable) now correctly
    preserves the directory structure using a more robust `find` and `cp`
    combination.

2.  **Corrected XML Descriptor Generation (`action.yml`):**
    *   Removed the non-standard top-level `<descriptor>` tag from
        `baseline.xml` and `current.xml`.
    *   Fixed `sed` typo for version update in `current.xml` generation
        (though now largely superseded by direct generation).
    *   Formatted `<include_paths>` to list each path directly on a new
        line, removing incorrect `<path>` sub-elements.
    *   Formatted `<skip_headers>` to list each pattern directly on a new
        line, removing incorrect `<n>` sub-elements.
    *   Formatted `<gcc_options>` to ensure each option is on a new line.
    *   XML files are now generated more directly, improving clarity.

3.  **Improved Workflow Error Handling (`api-compatibility.yaml`):**
    *   The workflow now correctly fails (exits with 1) if the custom
        action outputs `compatible=error` (e.g., if `api-sanity-checker`
        itself has an issue or reports cannot be generated/parsed).
        Previously, this state was treated as a success (exit 0) with
        only a warning message.

These changes enhance the reliability and correctness of the API
breakage detection mechanism. The XML descriptors now align better
with `api-sanity-checker`'s documented format, and the workflow's
response to errors is more appropriate for CI/CD pipelines.# Description

> Please check examples and comment out this sentence. Minimal example is [here](pull_request_samples/example_simple.md) and detailed example is [here](pull_request_samples/example_detail.md)

## Abstract

> [Required] This section is required, keep it short, clear and to the point.  
> Delete this sentence and explain this pull request shortly.  

## Background

> [Optional] If there is no background information that needs explanation (e.g., just a typo correction, etc.), you can skip this section.  
> Delete this sentence and explain the circumstances that led to this pull request being sent.  

## Details

> [Optional] If there are only differences whose effects are so obvious that no explanation is needed, or if there are no differences in the code (e.g., documentation additions), you can skip this section.  
> Delete this sentence and describe this pull request.  
> For example, it is desirable to describe the specifications of added functions, and detailed explanations of bugs that have been fixed.  

## References

> [Optional] If the referenced material does not exist, you can skip this section.  
> Describe any standards, algorithms, books, articles, etc. that you referenced when creating the pull request. If there is any novelty, mention it.  

# Destructive Changes

> [Optional] If no destructive change exists, you can skip this section.  
> Include a description of the changes and a migration guide and send the pull request with a bump major label. (Example : https://github.com/tier4/scenario_simulator_v2/pull/1139)  
> Otherwise, skip the "Destructive Changes" section and make sure this pull request is labeled `bump minor` or `bump patch`.  

# Known Limitations

> [Optional] If there are no known limitations that you can think of, you can skip this section. If there are any limitations on the features or fixes added by this pull request, delete this sentence and clearly describe them.
> For example, the lane matching algorithm currently (1/25/2024) employed is unable to match Entity that is heavily tilted with respect to the lane, and it is difficult to throw an exception.  
> If the developer is aware of the existence of such problems or limitations, describe them in detail. The problems or limitation should be listed as an Issue on GitHub and a link to it should be provided in this section.  
